### PR TITLE
Default media player settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,10 @@ Configuration
 The default player can be set in a ~/.config/yt settings file.  The format of the
 settings file should be like this (example for setting omxplayer as the default):
 
-[General]
-player = omxplayer
+::
+
+    [General]
+    player = omxplayer
 
 Valid options are ``mplayer``, ``omxplayer`` and ``omxplayerlocal``, for setting
 the default player to mplayer, omxplayer using the hdmi audio output and omxplayer

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,19 @@ Usage
       --player {mplayer,omxplayer}
                             specifies what program to use to play videos (default:
                         mplayer)
-                        
+
+Configuration
+-------------
+The default player can be set in a ~/.config/yt settings file.  The format of the
+settings file should be like this (example for setting omxplayer as the default):
+
+[General]
+player = omxplayer
+
+Valid options are ``mplayer``, ``omxplayer`` and ``omxplayerlocal``, for setting
+the default player to mplayer, omxplayer using the hdmi audio output and omxplayer
+using the local audio output, respectively.
+
 Dependancies
 ------------
 

--- a/src/yt/__init__.py
+++ b/src/yt/__init__.py
@@ -15,12 +15,13 @@ import argparse
 # Define possible player modes.
 MPLAYER_MODE="mplayer"
 OMXPLAYER_MODE="omxplayer"
+OMXPLAYERLOCAL_MODE="omxplayerlocal"
 
 def main():
 
     # Allow the user to specify whether to use mplayer or omxplayer for playing videos.
     parser = argparse.ArgumentParser(prog='yt',formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--player",default=MPLAYER_MODE,choices=[MPLAYER_MODE,OMXPLAYER_MODE],help="specifies what program to use to play videos")
+    parser.add_argument("--player",default=MPLAYER_MODE,choices=[MPLAYER_MODE,OMXPLAYER_MODE,OMXPLAYERLOCAL_MODE],help="specifies what program to use to play videos")
    
     args = parser.parse_args(sys.argv[1:])
 
@@ -375,11 +376,13 @@ def play_url(url,player):
         sys.stderr.write(err)
         raise RuntimeError('Error getting URL.')
 
-    assert player in [MPLAYER_MODE,OMXPLAYER_MODE]
+    assert player in [MPLAYER_MODE,OMXPLAYER_MODE,OMXPLAYERLOCAL_MODE]
     if player == MPLAYER_MODE:
         play_url_mplayer(url)
+    elif player == OMXPLAYER_MODE:
+		play_url_omxplayer(url)
     else:
-        play_url_omxplayer(url)
+        play_url_omxplayerlocal(url)
     
 def play_url_mplayer(url):
     player = subprocess.Popen(
@@ -390,6 +393,12 @@ def play_url_mplayer(url):
 def play_url_omxplayer(url):
     player = subprocess.Popen(
             ['omxplayer', '-ohdmi', url.decode('UTF-8').strip()],
+            stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+    player.wait()
+
+def play_url_omxplayerlocal(url):
+    player = subprocess.Popen(
+            ['omxplayer', url.decode('UTF-8').strip()],
             stdout = subprocess.PIPE, stderr = subprocess.PIPE)
     player.wait()
 

--- a/src/yt/__init__.py
+++ b/src/yt/__init__.py
@@ -11,6 +11,8 @@ import sys
 import urllib
 import urllib2
 import argparse
+import os
+import ConfigParser
 
 # Define possible player modes.
 MPLAYER_MODE="mplayer"
@@ -19,9 +21,21 @@ OMXPLAYERLOCAL_MODE="omxplayerlocal"
 
 def main():
 
-    # Allow the user to specify whether to use mplayer or omxplayer for playing videos.
+    # Read default settings, if they are there.
+    # If they are not there, or is set to something invalid, default to mplayer.
+    config = ConfigParser.RawConfigParser()
+    config_file = os.path.expanduser('~/.config/yt')
+    try:
+        config.read(config_file)
+        DEFAULT_MODE = config.get('General', 'player')
+        if DEFAULT_MODE not in [MPLAYER_MODE, OMXPLAYER_MODE, OMXPLAYERLOCAL_MODE]:
+            DEFAULT_MODE = MPLAYER_MODE
+    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+        DEFAULT_MODE = MPLAYER_MODE        
+
+    # Allow the user to specify whether to override the default player setting.
     parser = argparse.ArgumentParser(prog='yt',formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--player",default=MPLAYER_MODE,choices=[MPLAYER_MODE,OMXPLAYER_MODE,OMXPLAYERLOCAL_MODE],help="specifies what program to use to play videos")
+    parser.add_argument("--player",default=DEFAULT_MODE,choices=[MPLAYER_MODE,OMXPLAYER_MODE,OMXPLAYERLOCAL_MODE],help="specifies what program to use to play videos")
    
     args = parser.parse_args(sys.argv[1:])
 


### PR DESCRIPTION
Hi,

I have added the ability to read the default player from a ~/.config/yt settings file, so the user doesn't have to specify omxplayer at the command line all the time.

I also added a "--player omxplayerlocal" option, to be able to send the audio output to the local (analog) output of the raspberry pi.

Please review and pull if you like.

Regards,

George
