### PR TITLE
Added alternative entry point for Raspberry Pi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Launch using ``mplayer`` with::
 
 or, if you're using a Raspberry Pi, using ``omxplayer``::
 
-    yt --player omxplayer
+    pi-yt
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,17 @@ videos and play them directly from the command-line. It uses ``youtube-dl`` and
 The combination of a text based interface and ``omxplayer`` makes ``yt`` a great
 YouTube client for the Raspberry Pi.
 
+Usage
+-----
+
+Launch using ``mplayer`` with::
+
+    yt
+
+or, if you're using a Raspberry Pi, using ``omxplayer``::
+
+    yt --player omxplayer
+
 Installation
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,35 @@ YouTube client for the Raspberry Pi.
 Installation
 ------------
 
-1. Install setup tools. Eg. on a Debian based distro `sudo apt-get install python-setuptools`.
-2. From top level directory run `python setup.py install`.
+From PyPi (easier!)
+~~~~~~~~~~~~~~~~~~~
+
+::
+
+    # Install dependancies
+    sudo apt-get install youtube-dl
+    # Ensure using latest version of youtube-dl to keep up with YouTube API changes
+    sudo youtube-dl -U
+
+    # Install from PyPi
+    sudo apt-get install python-setuptools
+    sudo easy_install whitey
+
+From GitHub
+~~~~~~~~~~~
+
+::
+
+    # Install dependancies
+    sudo apt-get install youtube-dl
+    # Ensure using latest version of youtube-dl to keep up with YouTube API changes
+    sudo youtube-dl -U
+
+    # Install from GitHub
+    sudo apt-get install python-setuptools
+    git checkout git@github.com:rjw57/yt.git
+    cd yt
+    sudo python setup.py install
 
 Usage
 -----
@@ -39,15 +66,10 @@ Common problems
 Videos don't play when selected in interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Make sure you have the latest version of youtube-dl. The latest version in a package repository
-may lag significantly behind ongoing changes to YouTube. You can get the latest version
-by downloading youtube-dl directly from the GitHub repository.
+Make sure you have the latest version of youtube-dl. youtube-dl has a self update
+mechanism::
 
-Quick install instructions::
-
-    wget https://github.com/rg3/youtube-dl/blob/master/youtube-dl?raw=true
-    chmod +x youtube-dl
-    sudo mv youtube-dl /usr/bin/youtube
+    sudo youtube-dl -U
 
 Omxplayer starts and terminates without playing video
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -56,11 +78,13 @@ For high quality videos the default memory allocation on the Raspberry Pi doesn'
 provide enough memory to the GPU.
 
 The default 192M ARM, 64M GPU split can be changed to a 128M ARM, 128M GPU split
-by swapping the GPU firmware images.
+using raspi-config.
 
 ::
 
-    sudo cp /boot/arm128_start.elf /boot/start.elf.
+    sudo raspi-config
+    # Select memory-split
+    # Allocate 128M to the GPU
         
 See http://elinux.org/RPi_Advanced_Setup for more information.
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.2'
+version = '0.3'
 
 install_requires = [
     # List your project dependencies here.

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(name='whitey',
     install_requires=install_requires,
     entry_points={
         'console_scripts':
-            ['yt=yt:main']
+            [
+                'yt=yt:main',
+                'pi-yt=yt:main_with_omxplayer'
+            ]
     }
 )

--- a/src/yt/__init__.py
+++ b/src/yt/__init__.py
@@ -17,6 +17,9 @@ MPLAYER_MODE="mplayer"
 OMXPLAYER_MODE="omxplayer"
 
 def main():
+    """
+    Launch yt, allowing user to specify player.
+    """
 
     # Allow the user to specify whether to use mplayer or omxplayer for playing videos.
     parser = argparse.ArgumentParser(prog='yt',formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -25,6 +28,16 @@ def main():
     args = parser.parse_args(sys.argv[1:])
 
     ui = Ui(args.player)
+    ui.run()
+
+def main_with_omxplayer():
+    """
+    Launch yt, using omxplayer.
+    """
+
+    parser = argparse.ArgumentParser(prog='pi-yt')
+
+    ui = Ui(OMXPLAYER_MODE)
     ui.run()
 
 class ScreenSizeError(Exception):


### PR DESCRIPTION
Catching up with the attention that yt has been getting in the Pi forums I've seen a lot of people getting caught out by needing to the use the command line argument `--player omxplayer` so have added an alternative entry point for the Pi.
