### PR TITLE
I had problems while installing from Github ...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ From GitHub
 
     # Install from GitHub
     sudo apt-get install python-setuptools
-    git checkout git@github.com:rjw57/yt.git
+    git clone https://github.com/rjw57/yt.git
     cd yt
     sudo python setup.py install
 


### PR DESCRIPTION
...seems to work using the `clone` tool with the https address, instead of `checkout` + ssh.
